### PR TITLE
Avoid the bug of in_forward

### DIFF
--- a/src/Fluent/Logger/FluentLogger.php
+++ b/src/Fluent/Logger/FluentLogger.php
@@ -158,13 +158,10 @@ class FluentLogger extends BaseLogger
      */
     public static function pack_impl($tag, $data, $additional = null)
     {
-        $entry = array(time(), $data);
-        $array = array($entry);
-        
         if (!empty($additional)) {
             $tag .= "." . $additional;
         }
-        return json_encode(array($tag,$array));
+        return json_encode(array($tag, time(), $data));
     }
     
     /**


### PR DESCRIPTION
Hi,

I've modified pack_impl function, to avoid the bug of in_forward. When you use [tag, [[time, entry], [time, entry]]] format instead of [tag, time, entry] format, in_forward sometimes throws exception.

in_forward must be fixed. But for current PHP logger, this fix is just fine. Please merge this code!

thanks @fujiwara for pointing this out!
