### PR TITLE
Fixed: Test fails sometimes on 'FluentTests\Logger\JsonPackerTest::testP...

### DIFF
--- a/tests/Fluent/Logger/JsonPackerTest.php
+++ b/tests/Fluent/Logger/JsonPackerTest.php
@@ -7,6 +7,7 @@ use Fluent\Logger\JsonPacker;
 class JsonPackerTest extends \PHPUnit_Framework_TestCase
 {
     const TAG = "debug.test";
+    const EXPECTED_TIME = 123456789;
 
     protected $time;
     protected $expected_data = array();
@@ -14,12 +15,11 @@ class JsonPackerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->expected_data = array("abc"=>"def");
-        $this->time = time();
     }
 
     public function testPack()
     {
-        $entity = new Entity(self::TAG,$this->expected_data, $this->time);
+        $entity = new Entity(self::TAG,$this->expected_data, self::EXPECTED_TIME);
 
         $packer = new JsonPacker();
         $result = $packer->pack($entity);
@@ -45,7 +45,7 @@ class JsonPackerTest extends \PHPUnit_Framework_TestCase
      */
     public function testPackReturnTime($result)
     {
-        $this->assertEquals($result['1'],$this->time);
+        $this->assertEquals($result['1'], self::EXPECTED_TIME);
     }
 
     /**


### PR DESCRIPTION
Test fails sometime with:

```
PHPUnit 3.6.10 by Sebastian Bergmann.

Configuration read from fluent-logger-php/phpunit.xml.dist

ChainLogger: Fluent\Logger\FluentLogger failed fwrite retry: max retry count debug.test: {"hello":"world"}
...Entity::__construct(): unexpected time format `not int` specified.
.....Fluent\Logger\FluentLogger failed fwrite retry: max retry count debug.test: {"foo":"bar"}
.Mock_FluentLogger_a0d827b0 could not write message debug.test: {"foo":"bar"}
.Mock_FluentLogger_a0d827b0 connection aborted debug.test: {"foo":"bar"}
............F.

Time: 1 second, Memory: 9.50Mb

There was 1 failure:

1) FluentTests\Logger\JsonPackerTest::testPackReturnTime
Failed asserting that 1330079821 matches expected 1330079820.

fluent-logger-php/tests/Fluent/Logger/JsonPackerTest.php:49

FAILURES!
Tests: 24, Assertions: 34, Failures: 1.
```
