### PR TITLE
make sure connection is properly closed after having exception on socket

### DIFF
--- a/src/Fluent/Logger/FluentLogger.php
+++ b/src/Fluent/Logger/FluentLogger.php
@@ -333,6 +333,7 @@ class FluentLogger extends BaseLogger
         try {
             $this->reconnect();
         } catch (\Exception $e) {
+            $this->close();
             $this->processError($entity, $e->getMessage());
             return false;
         }
@@ -379,6 +380,7 @@ class FluentLogger extends BaseLogger
                 $buffer   = substr($packed,$written);
             }
         } catch (\Exception $e) {
+            $this->close();
             $this->processError($entity, $e->getMessage());
             return false;
         }


### PR DESCRIPTION
want to make sure the socket is properly closed when the exception happens. currently, if fwrite() returns FALSE, the connection isn't closed in postimpl.
