### PR TITLE
postImpl throws no exception

### DIFF
--- a/src/Fluent/Logger/FluentLogger.php
+++ b/src/Fluent/Logger/FluentLogger.php
@@ -327,7 +327,6 @@ class FluentLogger extends BaseLogger
      *
      * @param \Fluent\Logger\Entity $entity
      * @return bool
-     * @throws \Exception
      */
     protected function postImpl(Entity $entity)
     {


### PR DESCRIPTION
It looks that FluentLogger::postImpl does not throw any exception, because it catches all inside the method.