### PR TITLE
ignore files generated by composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ phpunit.xml
 cookbooks/
 tmp/
 *.iml
+composer.lock
+vendor


### PR DESCRIPTION
In php libraries, ignoring files generated by composer is best practice.

just like symfony.
https://github.com/symfony/symfony/blob/2.7/.gitignore