### PR TITLE
Add a minimal test case to reproduce the bug of hhvm and allow failures for hhvm on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - hhvm
 
 notifications:
   email: false
@@ -14,3 +15,7 @@ install: travis_retry composer install --no-interaction --prefer-source
 
 script:
   - vendor/bin/phpunit --coverage-text
+
+matrix:
+  allow_failures:
+    - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
 
 notifications:
   email: false

--- a/tests/Fluent/Logger/FluentLoggerTest.php
+++ b/tests/Fluent/Logger/FluentLoggerTest.php
@@ -48,6 +48,18 @@ class FluentLoggerTest extends \PHPUnit_Framework_TestCase
 //    }
 
     /**
+     *  fwrite on read only memory returns zero
+     *  HHVM has a bug which returns a positive integer
+     *  see https://github.com/facebook/hhvm/issues/5187
+     */
+    public function testFwriteOnReadonlyMemoryRreturnsZero()
+    {
+        $n = fwrite(fopen("php://memory", "r"), "hello");
+        $this->assertEquals(0, $n, "fwrite on ROM returns 0");
+    }
+
+
+    /**
      * Post will return false in the case of posting unsuccessfully by reached max retry count
      */
     public function testPostWillReturnFalseInTheCaseOfPostingUnsuccessfullyByReachedMaxRetryCount()


### PR DESCRIPTION
This branch includes the branch of  #25 

I think the best way is to add HHVM again in `.travis.yml` after the issue on HHVM is solved.

https://github.com/facebook/hhvm/issues/5187
