### PR TITLE
fix warning : Deprecated configuration setting "strict" used

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,9 @@
          stopOnIncomplete="false"
          stopOnSkipped="false"
          syntaxCheck="true"
+         reportUselessTests="true"
+         strictCoverage="true"
+         disallowTestOutput="true"
          verbose="true">
   <php>
     <ini name="date.timezone" value="Asia/Tokyo" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,6 @@
          stopOnIncomplete="false"
          stopOnSkipped="false"
          syntaxCheck="true"
-         strict="true"
          verbose="true">
   <php>
     <ini name="date.timezone" value="Asia/Tokyo" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,7 @@
          reportUselessTests="true"
          strictCoverage="true"
          disallowTestOutput="true"
+         beStrictAboutTestSize="true"
          verbose="true">
   <php>
     <ini name="date.timezone" value="Asia/Tokyo" />


### PR DESCRIPTION
the current phpunit.xml.dist raises a warning like below:

```
$ phpunit
PHPUnit 4.5.1 by Sebastian Bergmann and contributors.

Configuration read from /Users/DQNEO/src/github.com/DQNEO/fluent-logger-php/phpunit.xml.dist

Deprecated configuration setting "strict" used

The Xdebug extension is not loaded. No code coverage will be generated.

......ChainLogger: Fluent\Logger\FluentLogger failed fwrite retry: retry count exceeds limit. debug.test: {"hello":"world"}
...Entity::__construct(): unexpected time format `not int` specified.
........Fluent\Logger\FluentLogger failed fwrite retry: retry count exceeds limit. debug.test: {"foo":"bar"}
.Mock_FluentLogger_98f18707 could not write message debug.test: {"foo":"bar"}
.Mock_FluentLogger_98f18707 connection aborted debug.test: {"foo":"bar"}
........................

Time: 164 ms, Memory: 4.75Mb

OK (43 tests, 57 assertions)
```