### PR TITLE
Add unregisterErrorHandler() method

### DIFF
--- a/src/FluentLogger.php
+++ b/src/FluentLogger.php
@@ -166,6 +166,16 @@ class FluentLogger implements LoggerInterface
     }
 
     /**
+     * unregister error handler
+     *
+     * @return void
+     */
+    public function unregisterErrorHandler()
+    {
+        $this->error_handler = null;
+    }
+
+    /**
      * make a various style transport uri with specified host and port.
      * currently, in_forward uses tcp transport only.
      *

--- a/tests/Fluent/Logger/BaseLoggerTest.php
+++ b/tests/Fluent/Logger/BaseLoggerTest.php
@@ -64,4 +64,15 @@ class BaseLoggerTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
+
+    public function testUnregisterErrorHandler()
+    {
+        $base = $this->getMockForAbstractClass('Fluent\Logger\FluentLogger');
+        $prop = new \ReflectionProperty($base, 'error_handler');
+        $prop->setAccessible(true);
+        $base->registerErrorHandler(function() {});
+        $this->assertNotNull($prop->getValue($base));
+        $base->unregisterErrorHandler();
+        $this->assertNull($prop->getValue($base));
+    }
 }


### PR DESCRIPTION
sometimes GC does not properly cleanup FluentLogger objects because of registered error callback.
may be the reason is its first parameter, but I'm not exactly sure.
It would be good to have the possibility to manually unbind it.