### PR TITLE
 - added check for json_encode errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: php
 php:
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
@@ -19,7 +16,7 @@ script:
 
 matrix:
   include:
-    - php: 5.3
+    - php: 7.0
       dist: precise
   allow_failures:
     - php: hhvm

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Requirements
 
-- PHP 5.3 or higher
+- PHP 7.0 or higher
 - fluentd v0.9.20 or higher
 
 ## Installation
@@ -18,7 +18,7 @@ composer.json
 ```json
 {
     "require": {
-        "fluent/logger": "v1.0.0"
+        "fluent/logger": "~1.0"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=7.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.3",
-        "phpunit/phpunit-mock-objects": "2.3.0"
+        "phpunit/phpunit": "~6.0",
+        "phpunit/phpunit-mock-objects": "~4.0"
     },
     "autoload": {
         "psr-4": {"Fluent\\Logger\\": "src/"}

--- a/src/JsonPacker.php
+++ b/src/JsonPacker.php
@@ -16,6 +16,7 @@
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
  */
+
 namespace Fluent\Logger;
 
 class JsonPacker implements PackerInterface
@@ -28,10 +29,18 @@ class JsonPacker implements PackerInterface
      * pack entity as a json string.
      *
      * @param Entity $entity
+     *
      * @return string
+     * @throws \UnexpectedValueException
      */
     public function pack(Entity $entity)
     {
-        return json_encode(array($entity->getTag(), $entity->getTime(), $entity->getData()));
+        $json = json_encode(array($entity->getTag(), $entity->getTime(), $entity->getData()));
+
+        if (!$json and json_last_error() !== JSON_ERROR_NONE) {
+            throw new \UnexpectedValueException('Failed to encode data to json: ' . json_last_error_msg());
+        }
+
+        return $json;
     }
 }

--- a/tests/Fluent/Logger/BaseLoggerTest.php
+++ b/tests/Fluent/Logger/BaseLoggerTest.php
@@ -6,12 +6,13 @@ namespace FluentTests\FluentLogger;
 
 use Fluent\Logger;
 use Fluent\Logger\FluentLogger;
+use PHPUnit\Framework\TestCase;
 
 function fluentTests_FluentLogger_DummyFunction()
 {
 }
 
-class BaseLoggerTest extends \PHPUnit_Framework_TestCase
+class BaseLoggerTest extends TestCase
 {
     /**
      * testing compatible before and after

--- a/tests/Fluent/Logger/EntityTest.php
+++ b/tests/Fluent/Logger/EntityTest.php
@@ -2,8 +2,9 @@
 namespace FluentTests\Logger;
 
 use Fluent\Logger\Entity;
+use PHPUnit\Framework\TestCase;
 
-class EntityTest extends \PHPUnit_Framework_TestCase
+class EntityTest extends TestCase
 {
     const TAG = "debug.test";
 

--- a/tests/Fluent/Logger/FluentLoggerTest.php
+++ b/tests/Fluent/Logger/FluentLoggerTest.php
@@ -4,8 +4,9 @@ namespace FluentTests\FluentLogger;
 
 use Fluent\Logger;
 use Fluent\Logger\FluentLogger;
+use PHPUnit\Framework\TestCase;
 
-class FluentLoggerTest extends \PHPUnit_Framework_TestCase
+class FluentLoggerTest extends TestCase
 {
     const TAG          = 'debug.test';
     const OBJECT_KEY   = 'hello';
@@ -104,7 +105,11 @@ class FluentLoggerTest extends \PHPUnit_Framework_TestCase
 
     private function getMockOfLogger(array $method)
     {
-        return $this->getMock("Fluent\Logger\FluentLogger", array("write"), array("localhost"));
+        return $this
+            ->getMockBuilder("Fluent\Logger\FluentLogger")
+            ->setConstructorArgs(array("localhost"))
+            ->setMethods(array("write"))
+            ->getMock();
     }
 
     /**

--- a/tests/Fluent/Logger/JsonPackerTest.php
+++ b/tests/Fluent/Logger/JsonPackerTest.php
@@ -3,18 +3,21 @@ namespace FluentTests\Logger;
 
 use Fluent\Logger\Entity;
 use Fluent\Logger\JsonPacker;
+use PHPUnit\Framework\TestCase;
 
-class JsonPackerTest extends \PHPUnit_Framework_TestCase
+class JsonPackerTest extends TestCase
 {
     const TAG           = "debug.test";
     const EXPECTED_TIME = 123456789;
 
     protected $time;
-    protected $expected_data = array();
+    protected $expected_data;
+    protected $unexpected_data;
 
     public function setUp()
     {
         $this->expected_data = array("abc" => "def");
+        $this->unexpected_data = array("data" => random_bytes(100));
     }
 
     public function testPack()
@@ -31,6 +34,15 @@ class JsonPackerTest extends \PHPUnit_Framework_TestCase
         $this->assertStringMatchesFormat('["%s",%d,{"%s":"%s"}]', $result, "unexpected format returns");
 
         return json_decode($result, true);
+    }
+
+    public function testUnhandledJsonError()
+    {
+        $entity = new Entity(self::TAG, $this->unexpected_data, self::EXPECTED_TIME);
+
+        $this->expectException(\UnexpectedValueException::class);
+
+        (new JsonPacker)->pack($entity);
     }
 
     /**


### PR DESCRIPTION
In case of binary data or any other formats that json_encode() cant handle, fluent lib shouldn't silently drop..