### PR TITLE
Handle error_get_last() not returning an error message

### DIFF
--- a/src/FluentLogger.php
+++ b/src/FluentLogger.php
@@ -325,7 +325,14 @@ class FluentLogger implements LoggerInterface
 
         if (!$socket) {
             $errors = error_get_last();
-            throw new \Exception($errors['message']);
+            if (is_array($errors) && isset($errors['message'])) {
+                $message = $errors['message'];
+            } elseif (!empty($errstr)) {
+                $message = $errstr;
+            } else {
+                $message = "Unknow error connection to socket";
+            }
+            throw new \Exception($message);
         }
 
         // set read / write timeout.


### PR DESCRIPTION
This may be a PHP 7+ issue only. We recently had a few `Trying to access array offset on value of type null` errors in our logs from this code. Seems error_get_last() will not always return something when stream_socket_client() fails.