### PR TITLE
Fixing PHP 8.4 Implicitly nullable parameter declarations deprecated

### DIFF
--- a/src/FluentLogger.php
+++ b/src/FluentLogger.php
@@ -99,16 +99,16 @@ class FluentLogger implements LoggerInterface
      * create fluent logger object.
      *
      *
-     * @param string          $host
-     * @param int             $port
-     * @param array           $options
-     * @param PackerInterface $packer
+     * @param string               $host
+     * @param int                  $port
+     * @param array                $options
+     * @param PackerInterface|null $packer
      * @return FluentLogger
      */
     public function __construct($host = FluentLogger::DEFAULT_ADDRESS,
                                 $port = FluentLogger::DEFAULT_LISTEN_PORT,
                                 array $options = array(),
-                                PackerInterface $packer = null)
+                                $packer = null)
     {
         /* keep original host and port */
         $this->host = $host;
@@ -120,6 +120,8 @@ class FluentLogger implements LoggerInterface
         if (is_null($packer)) {
             /* for backward compatibility */
             $packer = new JsonPacker();
+        } elseif (!$packer instanceof PackerInterface) {
+            throw new \InvalidArgumentException(sprintf('The $packer parameter must implement %s. %s given.', PackerInterface::class, get_class($packer)));
         }
 
         $this->packer = $packer;


### PR DESCRIPTION
This dependency In PHP 8.4 now throws deprecation:
```
Fluent\Logger\FluentLogger::__construct(): Implicitly marking parameter $packer as nullable is deprecated, the explicit nullable type must be used instead
```

Recommendation from [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated) the solution is to explicitly mark the parameter as nullable, or avoid implicit nullability.

To maintain compatibility with PHP 5.6 while addressing this deprecation, I opted to:
* Remove the type hint for the `$packer` parameter to avoid the nullable deprecation in PHP 8.4.
* Manually check the `$packer` parameter type within the constructor, ensuring it either implements `PackerInterface` or is null. If it's not, an `InvalidArgumentException` is thrown.

This change ensures the code works as expected across all supported PHP versions, including PHP 5.6 and PHP 8.4.