### PR TITLE
Fix warning for PHP 8.4, for nullable type. Fixes #71.

### DIFF
--- a/src/FluentLogger.php
+++ b/src/FluentLogger.php
@@ -108,7 +108,7 @@ class FluentLogger implements LoggerInterface
     public function __construct($host = FluentLogger::DEFAULT_ADDRESS,
                                 $port = FluentLogger::DEFAULT_LISTEN_PORT,
                                 array $options = array(),
-                                PackerInterface $packer = null)
+                                ?PackerInterface $packer = null)
     {
         /* keep original host and port */
         $this->host = $host;


### PR DESCRIPTION
As documented in issue #71, here's a very simple fix, to prevent the error 

> Deprecated: Fluent\Logger\FluentLogger::__construct(): Implicitly marking parameter $packer as nullable is deprecated, the explicit nullable type must be used instead in /var/www/.../vendor/fluent/logger/src/FluentLogger.php on line 108
